### PR TITLE
Implements areResourcesAvailable service, console tested, see notes

### DIFF
--- a/edante/motion/CMakeLists.txt
+++ b/edante/motion/CMakeLists.txt
@@ -46,6 +46,7 @@ add_service_files(
   useHand.srv
   # Motion_Task
   getTaskList.srv
+  areResourcesAvailable.srv
   taskResource.srv
 )
 

--- a/edante/motion/src/motion_task.cpp
+++ b/edante/motion/src/motion_task.cpp
@@ -7,6 +7,8 @@ Motion_Task::Motion_Task(ros::NodeHandle* nh, AL::ALMotionProxy* mProxy)
 	INFO("Setting up Motion Task services" << std::endl);
   srv_get_task_list_ = nh_->advertiseService("getTaskList",
                                              &Motion_Task::getTaskList, this);
+  srv_are_res_avail_ = nh_->advertiseService("areResourcesAvailable",
+                                     &Motion_Task::areResourcesAvailable, this);
   srv_kill_tasks_res_ = nh_->advertiseService("killTasksUsingResources", 
                                         &Motion_Task::killTasksResources, this);
 	srv_kill_move_ = nh_->advertiseService("killMove", 
@@ -24,7 +26,6 @@ Motion_Task::~Motion_Task()
 bool Motion_Task::getTaskList(motion::getTaskList::Request &req,
                               motion::getTaskList::Response &res)
 {
-  // DEBUG(mProxy_->getTaskList() << std::endl);
   AL::ALValue taskList = mProxy_->getTaskList();
   string tName = taskList[0][0];
   int tID = taskList[0][1];
@@ -32,6 +33,13 @@ bool Motion_Task::getTaskList(motion::getTaskList::Request &req,
   res.taskList.resize(2);
   res.taskList[0].taskName = tName;
   res.taskList[0].motionID = tID;
+  return true;
+}
+
+bool Motion_Task::areResourcesAvailable(motion::areResourcesAvailable::Request &req,
+                                        motion::areResourcesAvailable::Response &res)
+{
+  res.available = mProxy_->areResourcesAvailable(req.resourceNames);
   return true;
 }
 

--- a/edante/motion/src/motion_task.h
+++ b/edante/motion/src/motion_task.h
@@ -9,6 +9,7 @@
 #include "motion/task.h"
 
 #include "motion/getTaskList.h"
+#include "motion/areResourcesAvailable.h"
 #include "motion/taskResource.h"
 
 #include <alproxies/almotionproxy.h>
@@ -26,6 +27,8 @@ public:
  //Motion task API
  bool getTaskList(motion::getTaskList::Request &req,
                   motion::getTaskList::Response &res);
+ bool areResourcesAvailable(motion::areResourcesAvailable::Request &req,
+                            motion::areResourcesAvailable::Response &res);
  bool killTasksResources(motion::taskResource::Request &req,
                          motion::taskResource::Response &res);
  bool killMove(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
@@ -35,6 +38,7 @@ private:
  //ROS
  ros::NodeHandle *nh_;
  ros::ServiceServer srv_get_task_list_;
+ ros::ServiceServer srv_are_res_avail_;
  ros::ServiceServer srv_kill_tasks_res_;
  ros::ServiceServer srv_kill_move_;
  ros::ServiceServer srv_kill_all_;

--- a/edante/motion/srv/areResourcesAvailable.srv
+++ b/edante/motion/srv/areResourcesAvailable.srv
@@ -1,0 +1,3 @@
+string[] resourceNames
+---
+bool available


### PR DESCRIPTION
- areResourcesAvailable service and srv file created, simple service. Always ask for lowest level resources if possible (see below)
- NOTE: NAOqi resource does not do name checking, i.e. default response to any resourceName is 'true'
- NOTE: NAOqi does not check if high level resource has lower level chain in use, i.e. if HeadYaw is occupied, Head resource will appear available, but a process will not execute until Headyaw is free
