### PR TITLE
Fix Nao falling if rest called mid-walk by calling stopMove first

### DIFF
--- a/edante/motion/src/joyRemote.cpp
+++ b/edante/motion/src/joyRemote.cpp
@@ -17,6 +17,7 @@ joyRemote::joyRemote(ros::NodeHandle* nh) {
   standClient = nh_->serviceClient<motion::setPosture>("/motion/goToPosture",
                 true);
   restClient = nh_->serviceClient<std_srvs::Empty>("/motion/rest", true);
+  stopMoveClient = nh_->serviceClient<std_srvs::Empty>("/motion/stopMove", true);
   INFO("Joystick remote node initialised" << std::endl);
   wakeUpFlag = false;
   moveInitFlag = false;
@@ -71,7 +72,10 @@ void joyRemote::stand() {
 }
 
 void joyRemote::rest() {
+  stopMoveClient.call(stopSrv);
+  sleep(0.25);
   moveInitClient.call(moveInitSrv);
+  sleep(0.25);
   restClient.call(restSrv);
   restFlag = false;
 }

--- a/edante/motion/src/joyRemote.h
+++ b/edante/motion/src/joyRemote.h
@@ -52,11 +52,13 @@ class joyRemote {
   std_srvs::Empty moveInitSrv;
   motion::setPosture standSrv;
   std_srvs::Empty restSrv;
+  std_srvs::Empty stopSrv;
   ros::ServiceClient moveTowardClient;
   ros::ServiceClient wakeUpClient;
   ros::ServiceClient moveInitClient;
   ros::ServiceClient standClient;
   ros::ServiceClient restClient;
+  ros::ServiceClient stopMoveClient;
 
 };
 


### PR DESCRIPTION
Important Joystick fix to avoid Nao falling
