### PR TITLE
Implement head tracking

### DIFF
--- a/edante/edante_msgs/vision_msgs/CMakeLists.txt
+++ b/edante/edante_msgs/vision_msgs/CMakeLists.txt
@@ -50,11 +50,11 @@ add_message_files(
 )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  StartHeadTracking.srv
+  StopHeadTracking.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(

--- a/edante/edante_msgs/vision_msgs/msg/BallDetection.msg
+++ b/edante/edante_msgs/vision_msgs/msg/BallDetection.msg
@@ -1,9 +1,17 @@
 Header header
+# True if the ball was detected
 bool is_detected
+# Area of the detected ball in pixels
 float32 area
+# Radius of the detected ball in pixels
 float32 radius
-geometry_msgs/Point32 pos_2d
-geometry_msgs/Point32 pos_3d
+# The 2D location where the ball was detected in the iamge
+geometry_msgs/Point32 pos_image
+# The 3D location of the ball in the camera frame
+geometry_msgs/Point32 pos_camera
+# The 3D location of the ball in the robot frame
+geometry_msgs/Point32 pos_robot
+# 0 to 1 certainty in the detection
 float32 certainty
 
 

--- a/edante/edante_msgs/vision_msgs/srv/StartHeadTracking.srv
+++ b/edante/edante_msgs/vision_msgs/srv/StartHeadTracking.srv
@@ -1,0 +1,5 @@
+# The type of object to be tracked
+# 0 - Ball
+uint8 object_type
+---
+bool result

--- a/edante/edante_msgs/vision_msgs/srv/StopHeadTracking.srv
+++ b/edante/edante_msgs/vision_msgs/srv/StopHeadTracking.srv
@@ -1,0 +1,5 @@
+# The type of object which to be not tracked anymore
+# 0 - Ball
+uint8 object_type
+---
+bool result

--- a/edante/motion/src/motion.cpp
+++ b/edante/motion/src/motion.cpp
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
                                              "RobotPosture");
   RobotPostureTest->rosSetup(&nh);
 
-  ros::Rate r(10);
+  ros::Rate r(30);
 
   while (ros::ok()) {
     ros::spinOnce();

--- a/edante/vision/CMakeLists.txt
+++ b/edante/vision/CMakeLists.txt
@@ -113,7 +113,8 @@ include_directories(
 add_executable(vision
   src/vision.cpp
   src/vision_node.cpp
-  src/ball_detector.cpp)
+  src/ball_detector.cpp
+  src/head_tracker.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes

--- a/edante/vision/include/vision/ball_detector.hpp
+++ b/edante/vision/include/vision/ball_detector.hpp
@@ -38,6 +38,10 @@ class BallDetector {
    */
   void ProcessImage(const sensor_msgs::Image& image,
                     const sensor_msgs::CameraInfo& cam_info);
+  /**
+   * @brief Getter of the current ball detection
+   */
+  const vision_msgs::BallDetection& ball() const { return ball_detection_; }
 
  private:
   // Ball radius in meters

--- a/edante/vision/include/vision/head_tracker.hpp
+++ b/edante/vision/include/vision/head_tracker.hpp
@@ -1,0 +1,58 @@
+/*
+* @copyright: Copyright[2015]<Svetlin Penkov>
+*      @date: 2015-06-04
+*     @email: s.v.penkov@sms.ed.ac.uk
+*      @desc: Implements head tracking of an object in the image.
+*/
+#ifndef HEAD_TRACKER_HPP
+#define HEAD_TRACKER_HPP
+
+#include <ros/ros.h>
+
+#include <vision_msgs/BallDetection.h>
+#include <vision_msgs/StartHeadTracking.h>
+#include <vision_msgs/StopHeadTracking.h>
+
+#include <motion_msgs/ChangeAngles.h>
+
+class HeadTracker {
+ public:
+  enum TrackedObjectType {None = -1, Ball = 0};
+  /**
+   * @brief Initialises the services
+   *
+   * @param nh The node handle to be used
+   */
+  explicit HeadTracker(ros::NodeHandle& nh);
+  /**
+   * @brief This function moves the head toward the object of interest
+   * @details The object of interest is selected based on the value of
+   *          object_type_. Currently, only ball is supported.
+   *
+   * @param ball The detected ball by the ball detector.
+   */
+  void Track(const vision_msgs::BallDetection& ball);
+
+ private:
+  // Service servers
+  ros::ServiceServer start_head_tracking_server_;
+  ros::ServiceServer stop_head_tracking_server_;
+  // Service client
+  ros::ServiceClient change_angles_client_;
+  // Preallocated change angles message
+  motion_msgs::ChangeAngles change_angles_srv_;
+
+  // Whether tracking is enabled
+  bool is_enabled_;
+  // The type of object to track (only Ball is currently supported)
+  TrackedObjectType object_type_;
+
+  // Service callbacks
+  bool start_head_tracking(vision_msgs::StartHeadTracking::Request&  req,
+                           vision_msgs::StartHeadTracking::Response& res);
+  bool stop_head_tracking(vision_msgs::StopHeadTracking::Request&  req,
+                          vision_msgs::StopHeadTracking::Response& res);
+};
+
+#endif
+

--- a/edante/vision/include/vision/vision_node.hpp
+++ b/edante/vision/include/vision/vision_node.hpp
@@ -21,6 +21,7 @@
 #include <sensor_msgs/CameraInfo.h>
 
 #include "vision/ball_detector.hpp"
+#include "vision/head_tracker.hpp"
 
 /**
  * @brief Reads the segmented image and the corresponding camera infro
@@ -52,6 +53,9 @@ class VisionNode {
   // Detects the ball and publishes information
   BallDetector ball_detector_;
 
+  // Head tracking
+  HeadTracker head_tracker_;
+
   /**
    * @brief Retrieves the camera data stored in the shared memory.
    * @details Retreives the current camera info and image stored
@@ -64,15 +68,6 @@ class VisionNode {
    */
   bool SharedMemoryToCamera(sensor_msgs::Image& image,
                             sensor_msgs::CameraInfo& cam_info);
-  /**
-   * @brief Called every time new camera information is received.
-   * @details Runs the image processing in order to extract useful information.
-   *
-   * @param image The image to be processed.
-   * @param cam_info The calibration information of the camera
-   */
-  void CameraCallback(const sensor_msgs::Image& image,
-                      const sensor_msgs::CameraInfo& cam_info);
 };
 
 #endif

--- a/edante/vision/src/head_tracker.cpp
+++ b/edante/vision/src/head_tracker.cpp
@@ -1,0 +1,87 @@
+/*
+* @copyright: Copyright[2015]<Svetlin Penkov>
+*      @date: 2015-06-04
+*     @email: s.v.penkov@sms.ed.ac.uk
+*      @desc: Implements head tracking of an object in the image.
+*/
+#include "vision/head_tracker.hpp"
+
+/**
+ * @brief Initialises the services
+ *
+ * @param nh The node handle to be used
+ */
+HeadTracker::HeadTracker(ros::NodeHandle& nh) :
+  start_head_tracking_server_(
+    nh.advertiseService("start_head_tracking",
+                        &HeadTracker::start_head_tracking,
+                        this)),
+  stop_head_tracking_server_(
+    nh.advertiseService("stop_head_tracking",
+                        &HeadTracker::stop_head_tracking,
+                        this)),
+  change_angles_client_(
+    nh.serviceClient<motion_msgs::ChangeAngles>("/motion/change_angles",
+                                                true)),
+  is_enabled_(false) {
+  // Preallocate the change angles message
+  change_angles_srv_.request.names.push_back("HeadYaw");
+  change_angles_srv_.request.names.push_back("HeadPitch");
+  change_angles_srv_.request.changes.push_back(0.0f);
+  change_angles_srv_.request.changes.push_back(0.0f);
+  change_angles_srv_.request.fraction_max_speed = 0.8f;
+}
+/**
+ * @brief This function moves the head toward the object of interest
+ * @details The object of interest is selected based on the value of
+ *          object_type_. Currently, only ball is supported.
+ *
+ * @param ball The detected ball by the ball detector.
+ */
+void HeadTracker::Track(const vision_msgs::BallDetection& ball) {
+  if (!is_enabled_) return;
+
+  // Check where should the head look
+  geometry_msgs::Point32 track_pos;
+  switch (object_type_) {
+    case Ball: {
+      // If tracking the ball, but it is not visible - do nothing.
+      if (!ball.is_detected) return;
+      track_pos = ball.pos_camera;
+      break;
+    }
+    default:
+      return;
+  }
+  // Calculate the angles to the ball in the camera frame.
+  float yaw = atan2(track_pos.y, track_pos.x);
+  float pitch = atan2(track_pos.z, track_pos.x);
+  // Apply proportional control. Those coefficiants lead to
+  // slighly underdamped behaviour, but provide fast reaction.
+  change_angles_srv_.request.changes[0] = 0.20 * yaw;
+  change_angles_srv_.request.changes[1] = -0.20 * pitch;
+  // Send the command to motion
+  change_angles_client_.call(change_angles_srv_);
+}
+bool HeadTracker::start_head_tracking(
+  vision_msgs::StartHeadTracking::Request& req,
+  vision_msgs::StartHeadTracking::Response& res) {
+  is_enabled_ = true;
+  object_type_ = static_cast<TrackedObjectType>(req.object_type);
+  res.result = true;
+  return true;
+}
+
+bool HeadTracker::stop_head_tracking(
+  vision_msgs::StopHeadTracking::Request& req,
+  vision_msgs::StopHeadTracking::Response& res) {
+  if (object_type_ == static_cast<TrackedObjectType>(req.object_type)) {
+    is_enabled_ = false;
+    object_type_ = None;
+    res.result = true;
+  } else {
+    res.result = false;
+  }
+  return true;
+}
+


### PR DESCRIPTION
Implement generic object tracking by the head. Currently, only the
ball is supported. In order to start or stop the head tracking behaviour the `/vision/start_head_tracking` and `/vision/stop_head_tracking` services should be used.
