### PR TITLE
Add automatic camera switch when tracking

### DIFF
--- a/edante/vision/CMakeLists.txt
+++ b/edante/vision/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_geometry
   image_transport
   camera
+  camera_msgs
   vision_msgs
   motion_msgs
 )

--- a/edante/vision/include/vision/head_tracker.hpp
+++ b/edante/vision/include/vision/head_tracker.hpp
@@ -9,11 +9,16 @@
 
 #include <ros/ros.h>
 
+#include <camera_msgs/SetActiveCamera.h>
+#include <motion_msgs/ChangeAngles.h>
+#include <motion_msgs/GetAngles.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <vision_msgs/BallDetection.h>
 #include <vision_msgs/StartHeadTracking.h>
 #include <vision_msgs/StopHeadTracking.h>
 
-#include <motion_msgs/ChangeAngles.h>
+
+
 
 class HeadTracker {
  public:
@@ -29,18 +34,26 @@ class HeadTracker {
    * @details The object of interest is selected based on the value of
    *          object_type_. Currently, only ball is supported.
    *
+   * @param cam_info The information of the camera used for detection.
    * @param ball The detected ball by the ball detector.
    */
-  void Track(const vision_msgs::BallDetection& ball);
+  void Track(const sensor_msgs::CameraInfo& cam_info,
+             const vision_msgs::BallDetection& ball);
 
  private:
   // Service servers
   ros::ServiceServer start_head_tracking_server_;
   ros::ServiceServer stop_head_tracking_server_;
-  // Service client
+  ros::ServiceClient set_active_camera_client_;
+  ros::ServiceClient get_angles_client_;
   ros::ServiceClient change_angles_client_;
-  // Preallocated change angles message
+  // Preallocated messages
+  camera_msgs::SetActiveCamera set_active_camera_srv_;
+  motion_msgs::GetAngles get_angles_srv_;
   motion_msgs::ChangeAngles change_angles_srv_;
+
+
+
 
   // Whether tracking is enabled
   bool is_enabled_;

--- a/edante/vision/src/ball_detector.cpp
+++ b/edante/vision/src/ball_detector.cpp
@@ -163,7 +163,6 @@ void BallDetector::EstimateBallPos3D(
   cam_pos_3d *= kBallRadius / radius_z1m;
 
   // Transform the point from the optical camera frame to the Nao camera frame
-  Point3d pos_3d;
   ball.pos_camera.x = cam_pos_3d.z;
   ball.pos_camera.y = -cam_pos_3d.x;
   ball.pos_camera.z = -cam_pos_3d.y;
@@ -187,9 +186,15 @@ void BallDetector::EstimateBallPos3D(
 
   // Apply the transformation to get the ball in the robot frame.
   vector<float>& T = srv.response.transform;
-  ball.pos_robot.x = T[0] * pos_3d.x + T[1] * pos_3d.y + T[2] * pos_3d.z + T[3];
-  ball.pos_robot.y = T[4] * pos_3d.x + T[5] * pos_3d.y + T[6] * pos_3d.z + T[7];
-  ball.pos_robot.z = T[8] * pos_3d.x + T[9] * pos_3d.y + T[10] * pos_3d.z + T[11];
+  ball.pos_robot.x = T[0] * ball.pos_camera.x +
+                     T[1] * ball.pos_camera.y +
+                     T[2] * ball.pos_camera.z + T[3];
+  ball.pos_robot.y = T[4] * ball.pos_camera.x +
+                     T[5] * ball.pos_camera.y +
+                     T[6] * ball.pos_camera.z + T[7];
+  ball.pos_robot.z = T[8] * ball.pos_camera.x +
+                     T[9] * ball.pos_camera.y +
+                     T[10] * ball.pos_camera.z + T[11];
 }
 
 

--- a/edante/vision/src/head_tracker.cpp
+++ b/edante/vision/src/head_tracker.cpp
@@ -20,11 +20,20 @@ HeadTracker::HeadTracker(ros::NodeHandle& nh) :
     nh.advertiseService("stop_head_tracking",
                         &HeadTracker::stop_head_tracking,
                         this)),
+  set_active_camera_client_(
+    nh.serviceClient<camera_msgs::SetActiveCamera>("/camera/set_active_camera",
+                                                   true)),
+  get_angles_client_(
+    nh.serviceClient<motion_msgs::GetAngles>("/motion/get_angles",
+                                             true)),
   change_angles_client_(
     nh.serviceClient<motion_msgs::ChangeAngles>("/motion/change_angles",
                                                 true)),
   is_enabled_(false) {
-  // Preallocate the change angles message
+  // Preallocate the GetAngles message
+  get_angles_srv_.request.names.push_back("HeadPitch");
+  get_angles_srv_.request.use_sensors = true;
+  // Preallocate the ChangeAngles message
   change_angles_srv_.request.names.push_back("HeadYaw");
   change_angles_srv_.request.names.push_back("HeadPitch");
   change_angles_srv_.request.changes.push_back(0.0f);
@@ -36,9 +45,11 @@ HeadTracker::HeadTracker(ros::NodeHandle& nh) :
  * @details The object of interest is selected based on the value of
  *          object_type_. Currently, only ball is supported.
  *
+ * @param cam_info The information of the camera used for detection.
  * @param ball The detected ball by the ball detector.
  */
-void HeadTracker::Track(const vision_msgs::BallDetection& ball) {
+void HeadTracker::Track(const sensor_msgs::CameraInfo& cam_info,
+                        const vision_msgs::BallDetection& ball) {
   if (!is_enabled_) return;
 
   // Check where should the head look
@@ -53,13 +64,49 @@ void HeadTracker::Track(const vision_msgs::BallDetection& ball) {
     default:
       return;
   }
+
+  // Get current angles
+  get_angles_client_.call(get_angles_srv_);
+  float yaw = get_angles_srv_.response.joint_angles[0];
+  // Check if a camera switch is needed.
+  // If the head is tilted down too much and the top camera is used
+  // then switch to bottom camera.
+  if (yaw > 0.45 && cam_info.header.frame_id == "top_camera") {
+    // Activate bottom camera
+    set_active_camera_srv_.request.active_camera = 1;
+    set_active_camera_client_.call(set_active_camera_srv_);
+    // Move the head up so that the ball is visible from the bottom camera.
+    change_angles_srv_.request.changes[0] = 0;
+    change_angles_srv_.request.changes[1] = -0.5;
+    change_angles_client_.call(change_angles_srv_);
+    // Wait for movement - we do not want to process empty frames.
+    ros::Duration d(0.2);
+    d.sleep();
+    return;
+  }
+  // If the head is tilted up too much and the bottom camera is used
+  // then switch to top camera.
+  if (yaw < -0.4 && cam_info.header.frame_id == "bottom_camera") {
+    // Activate top camera
+    set_active_camera_srv_.request.active_camera = 0;
+    set_active_camera_client_.call(set_active_camera_srv_);
+    // Move the head down so that the ball is visible from the top camera.
+    change_angles_srv_.request.changes[0] = 0;
+    change_angles_srv_.request.changes[1] = 0.5;
+    change_angles_client_.call(change_angles_srv_);
+    // Wait for movement - we do not want to process empty frames.
+    ros::Duration d(0.2);
+    d.sleep();
+    return;
+  }
+
   // Calculate the angles to the ball in the camera frame.
-  float yaw = atan2(track_pos.y, track_pos.x);
-  float pitch = atan2(track_pos.z, track_pos.x);
+  float d_yaw = atan2(track_pos.y, track_pos.x);
+  float d_pitch = atan2(track_pos.z, track_pos.x);
   // Apply proportional control. Those coefficiants lead to
   // slighly underdamped behaviour, but provide fast reaction.
-  change_angles_srv_.request.changes[0] = 0.20 * yaw;
-  change_angles_srv_.request.changes[1] = -0.20 * pitch;
+  change_angles_srv_.request.changes[0] = 0.20 * d_yaw;
+  change_angles_srv_.request.changes[1] = -0.20 * d_pitch;
   // Send the command to motion
   change_angles_client_.call(change_angles_srv_);
 }

--- a/edante/vision/src/vision_node.cpp
+++ b/edante/vision/src/vision_node.cpp
@@ -40,7 +40,7 @@ void VisionNode::Spin() {
   while (ros::ok()) {
     if (SharedMemoryToCamera(image, cam_info)) {
       ball_detector_.ProcessImage(image, cam_info);
-      head_tracker_.Track(ball_detector_.ball());
+      head_tracker_.Track(cam_info, ball_detector_.ball());
     }
     ros::spinOnce();
     rate.sleep();


### PR DESCRIPTION
- The head tracker automatically chooses which camera to use
  when tracking the ball.
- Fix a bug related to the 3D position of the ball.
