### PR TITLE
Add a script which installs edante on a robot (#73)

### DIFF
--- a/tools/install_edante.sh
+++ b/tools/install_edante.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Create config folder
+mkdir -p /home/nao/config/camera
+# Add empty calibration files
+cp ./resources/top.yaml /home/nao/config/camera/
+cp ./resources/bottom.yaml /home/nao/config/camera/
+
+# Update autload.ini so that naoqi loads the camera module
+cp ./resources/autoload.ini /home/nao/naoqi/preferences/
+
+# Add ros service
+sudo /resources/ros /etc/init.d/
+sudo rc-update add ros default
+
+# Update naoqi service
+cp ./resources/naoqi /etc/init.d/

--- a/tools/resources/autoload.ini
+++ b/tools/resources/autoload.ini
@@ -1,0 +1,14 @@
+# autoload.ini
+#
+# Use this file to list the cross-compiled modules that you wish to load.
+# You must specify the full path to the module, python module or program.
+
+[user]
+#the/full/path/to/your/liblibraryname.so  # load liblibraryname.so
+/home/nao/ros/devel/lib/libcamera_node.so
+
+[python]
+#the/full/path/to/your/python_module.py   # load python_module.py
+
+[program]
+#the/full/path/to/your/program            # load program

--- a/tools/resources/bottom.yaml
+++ b/tools/resources/bottom.yaml
@@ -1,5 +1,5 @@
-image_width: 640
-image_height: 480
+image_width: 320
+image_height: 240
 camera_name: bottom
 camera_matrix:
   rows: 0

--- a/tools/resources/naoqi
+++ b/tools/resources/naoqi
@@ -1,0 +1,88 @@
+#!/sbin/runscript
+##
+## Author(s):
+##  - Cedric GESTES <gestes@aldebaran-robotics.com>
+##  - Samuel MARTIN <smartin@aldebaran-robotics.com>
+##
+## Copyright (C) 2010 - 2012 Aldebaran Robotics
+##
+
+LOCK_FILE="/var/lock/naoqi.lock"
+LOG_DIR="/var/log/naoqi"
+BINARY="/usr/bin/naoqi-bin"
+NAOQI_USER="nao"
+ARGS=""
+
+depend(){
+  need dbus localmount ros
+  use sysklog hald
+}
+
+start() {
+
+  local bin=$(basename "${BINARY}")
+  #still a pid file?
+  if [ -f "${LOCK_FILE}" ] ; then
+    #still the running process?
+    if kill -0 $(cat "${LOCK_FILE}") 2>/dev/null ; then
+      ewarn "!! Warning: naoqi is already running !!"
+      ewarn "if you are sure it is not running, remove ${LOCK_FILE}."
+      return 1
+    fi
+  fi
+  if killall -0 "${bin}" 2>/dev/null ; then
+    ewarn "!! Warning: naoqi is already running !!"
+    ewarn "Please, stop it (killall ${bin}) before starting it again."
+    return 1
+  fi
+  ebegin "Starting naoqi"
+  mkdir -p "${LOG_DIR}"
+  chown $(id -u "${NAOQI_USER}"):$(id -g "${NAOQI_USER}") "${LOG_DIR}"
+  for f in /etc/babile.conf /etc/babear4.conf ; do
+    [ -f /etc/babear4.conf"${f}" ] && \
+      chown $(id -u "${NAOQI_USER}"):$(id -g "${NAOQI_USER}") "${f}"
+  done
+
+  if [ nao = $(whoami) ]; then
+    source /opt/openrobots/etc/ros/setup.sh
+    #user nao, already have a dbus session
+    "${BINARY}" --daemon --pid "${LOCK_FILE}" ${ARGS}
+  else
+    #we want a dbus session
+    su -c ". /opt/openrobots/etc/ros/setup.sh; . /etc/profile.d/dbus-session.sh; ${BINARY} --daemon --pid ${LOCK_FILE} ${ARGS}" - nao
+  fi
+  eend $? "cannot start naoqi"
+}
+
+stop() {
+  ebegin "Stopping naoqi"
+  local bin=$(basename "${BINARY}")
+  if [ -f "${LOCK_FILE}" ] ; then
+    if kill -0 $(cat "${LOCK_FILE}") 2>/dev/null ; then
+      kill $(cat "${LOCK_FILE}")
+      #waiting for naoqi to shutdown
+      einfo "waiting for naoqi to shutdown"
+      while kill -0 $(cat ${LOCK_FILE}) 2>/dev/null ; do
+        sleep 1
+      done
+      einfo "Naoqi stopped"
+    fi
+  fi
+  if killall -0 "${bin}" &>/dev/null; then
+    ewarn "kill all remaining ${bin} processes"
+    local try=1
+    while killall -0 "${bin}" &>/dev/null && [ ${try} -gt 0 ] ; do
+      killall -9 "${bin}"
+      try=$(( ${try} - 1 ))
+      sleep 2
+    done
+  fi
+  rm -f "${LOCK_FILE}"
+  eend $?
+}
+
+restart() {
+  stop
+  sleep 2
+  start
+}

--- a/tools/resources/ros
+++ b/tools/resources/ros
@@ -1,0 +1,24 @@
+#!/sbin/runscript
+
+depend () {
+  need dbus localmount
+  provide ros
+}
+
+start() {
+  ebegin "Starting roscore"
+  source /opt/openrobots/etc/ros/setup.sh
+  start-stop-daemon --background --start --quiet --exec /opt/openrobots/bin/roscore \
+                    --make-pidfile --pidfile /var/run/ros.pid
+  einfo "Waiting for the rosmaster"
+  sleep 10
+  eend $?
+}
+
+stop() {
+  ebegin "Stoping roscore"
+  start-stop-daemon --stop --exec /usr/bin/python2.7 --name /opt/openrobots/bin/roscore \
+                    --pidfile /var/run/ros.pid
+  eend $?
+}
+

--- a/tools/resources/top.yaml
+++ b/tools/resources/top.yaml
@@ -1,5 +1,5 @@
-image_width: 640
-image_height: 480
+image_width: 320
+image_height: 240
 camera_name: top
 camera_matrix:
   rows: 0


### PR DESCRIPTION
The script creates the required folders and puts default config files
for camera claibration. It also makes roscore to be started
automatically. When the robot has booted roscore, naoqi and the camera
ROS node are running. The script has to be executed only once.
