### PR TITLE
Implement a Kalman filter for the ball position

### DIFF
--- a/edante/vision/include/vision/ball_detector.hpp
+++ b/edante/vision/include/vision/ball_detector.hpp
@@ -12,6 +12,7 @@
 
 // OpenCV
 #include <opencv2/core/core.hpp>
+#include <opencv2/video/tracking.hpp>
 
 // ROS
 #include <ros/ros.h>
@@ -39,7 +40,8 @@ class BallDetector {
    * @param cam_model The calibrated camera model.
    * @param transform The camera frame transformation at frame capture
    */
-  void ProcessImage(const cv::Mat& image,
+  void ProcessImage(cv::Mat& image,
+                    int horizon,
                     const std_msgs::Header& header,
                     const image_geometry::PinholeCameraModel& cam_model,
                     const std::vector<float>& transform);
@@ -49,15 +51,24 @@ class BallDetector {
   const vision_msgs::BallDetection& ball() const { return ball_detection_; }
 
  private:
+  static const int kImageKFStateSize = 6;
+  static const int kImageKFMeasurementSize = 4;
+  static const float kMaxStateVariance = 1000;
+  static const float kMaxPositionVariance = 25;
+
   // Ball radius in meters
-  static const double kBallRadius;
+  static const double kBallRadius = 0.03;
 
   // The processed image
   cv::Mat image_;
+  int horizon_;
   // Detected contours
   std::vector< std::vector<cv::Point> > contours_;
   // Information about the detected ball
   vision_msgs::BallDetection ball_detection_;
+
+  cv::KalmanFilter kf_2d_;
+
   // Publisher of the detected ball
   ros::Publisher ball_detection_pub_;
 

--- a/edante/vision/src/ball_detector.cpp
+++ b/edante/vision/src/ball_detector.cpp
@@ -17,18 +17,82 @@
 
 using std::vector;
 
+using cv::Mat;
+using cv::Mat_;
 using cv::Rect;
 using cv::Point2d;
 using cv::Point3d;
 
-const double BallDetector::kBallRadius = 0.03;
+
 /**
  * @brief Creates the BallDetection publisher and the GetTransform client.
  *
  * @param nh The node handle to be used.
  */
 BallDetector::BallDetector(ros::NodeHandle& nh) :
+  kf_2d_(kImageKFStateSize, kImageKFMeasurementSize),
   ball_detection_pub_(nh.advertise<vision_msgs::BallDetection>("ball", 5)) {
+
+  // Transition State Matrix A
+  // [ 1 0 dT 0  0 0 ]
+  // [ 0 1 0  dT 0 0 ]
+  // [ 0 0 1  0  0 0 ]
+  // [ 0 0 0  1  0 0 ]
+  // [ 0 0 0  0  1 0 ]
+  // [ 0 0 0  0  0 1 ]
+  kf_2d_.transitionMatrix.at<float>(0, 0) = 1;
+  kf_2d_.transitionMatrix.at<float>(1, 1) = 1;
+  kf_2d_.transitionMatrix.at<float>(2, 2) = 1;
+  kf_2d_.transitionMatrix.at<float>(3, 3) = 1;
+  kf_2d_.transitionMatrix.at<float>(4, 4) = 1;
+  kf_2d_.transitionMatrix.at<float>(5, 5) = 1;
+  // TODO(svepe): Update dT at each processing step!
+  kf_2d_.transitionMatrix.at<float>(0, 2) = 1.0 / 30.0;
+  kf_2d_.transitionMatrix.at<float>(1, 3) = 1.0 / 30.0;
+
+  // Measure Matrix H
+  // [ 1 0 0 0 0 0 ]
+  // [ 0 1 0 0 0 0 ]
+  // [ 0 0 0 0 1 0 ]
+  // [ 0 0 0 0 0 1 ]
+  kf_2d_.measurementMatrix.at<float>(0, 0) = 1.0f;
+  kf_2d_.measurementMatrix.at<float>(1, 1) = 1.0f;
+  kf_2d_.measurementMatrix.at<float>(2, 4) = 1.0f;
+  kf_2d_.measurementMatrix.at<float>(3, 5) = 1.0f;
+
+  // Process Noise Covariance Matrix Q
+  //
+  // The result will be smoother with lower values. If the value of Q
+  // is high, it means that the measured signal varies quickly and
+  // the filter needs to be adaptable. If it is small, then big variations
+  // will be attributed to noise in the measure.
+
+
+  // [ Var(x)   0      0        0         0      0    ]
+  // [   0    Var(y)   0        0         0      0    ]
+  // [   0      0    Var(v_x)   0         0      0    ]
+  // [   0      0      0      Var(Ev_y)   0      0    ]
+  // [   0      0      0        0       Var(w)   0    ]
+  // [   0      0      0        0         0    Var(h) ]
+  kf_2d_.processNoiseCov.at<float>(0, 0) = 1e-2;
+  kf_2d_.processNoiseCov.at<float>(1, 1) = 1e-2;
+  kf_2d_.processNoiseCov.at<float>(2, 2) = 1e-1;
+  kf_2d_.processNoiseCov.at<float>(3, 3) = 1e-1;
+  kf_2d_.processNoiseCov.at<float>(4, 4) = 1e-2;
+  kf_2d_.processNoiseCov.at<float>(5, 5) = 1e-2;
+
+  // Measures Noise Covariance Matrix R
+  //
+  // The result will be smoother with higher values. If the value of R is high
+  // (compared to Q), it will indicate that the measuring is noisy so it will
+  // be filtered more.
+  kf_2d_.measurementNoiseCov.at<float>(0, 0) = 1e-1;
+  kf_2d_.measurementNoiseCov.at<float>(1, 1) = 1;
+  kf_2d_.measurementNoiseCov.at<float>(2, 2) = 1;
+  kf_2d_.measurementNoiseCov.at<float>(3, 3) = 1e-1;
+
+  // kf_2d_.errorCovPost = Mat_<float>::eye(kImageKFStateSize,
+  //                                        kImageKFStateSize) * 1000;
 }
 /**
  * @brief Detect the ball in the image.
@@ -40,12 +104,16 @@ BallDetector::BallDetector(ros::NodeHandle& nh) :
  * @param transform The camera frame transformation at frame capture
  */
 void BallDetector::ProcessImage(
-  const cv::Mat& image,
+  cv::Mat& image,
+  int horizon,
   const std_msgs::Header& header,
   const image_geometry::PinholeCameraModel& cam_model,
   const std::vector<float>& transform) {
-  // Copy the input image
-  image_ = image.clone();
+  // Make a subimage under the horizon line
+  horizon_ = horizon;
+  image_ = Mat(image.rows - horizon_,
+               image.cols, CV_8UC1,
+               image.data + horizon_ * image.cols);
 
   // Make only ball pixels white
   ThresholdImage(image_);
@@ -114,15 +182,37 @@ void BallDetector::FindBall(cv::Mat& image,
     }
   }
 
-  ball.is_detected = (max_index != -1);
+  Mat_<float> state = kf_2d_.predict();
 
-  if (ball.is_detected) {
+  if (max_index != -1) {
     Rect r = cv::boundingRect(contours_[max_index]);
+    Mat_<float> m(kImageKFMeasurementSize, 1);
+    m.at<float>(0) = r.x + r.width / 2;
+    m.at<float>(1) = r.y + r.height / 2 + horizon_;
+    m.at<float>(2) = r.width;
+    m.at<float>(3) = r.height;
+    state = kf_2d_.correct(m);
+  } else {
+    kf_2d_.statePost = kf_2d_.statePre;
+    kf_2d_.errorCovPost = kf_2d_.errorCovPre;
+  }
 
+  for (int i = 0; i < kf_2d_.errorCovPost.rows; ++i) {
+    for (int j = 0; j < kf_2d_.errorCovPost.cols; ++j) {
+      if (kf_2d_.errorCovPost.at<float>(i, j) > kMaxStateVariance)
+        kf_2d_.errorCovPost.at<float>(i, j) = kMaxStateVariance;
+    }
+  }
+
+  float pos_var = fabs(kf_2d_.errorCovPost.at<float>(0, 0)) +
+                  fabs(kf_2d_.errorCovPost.at<float>(1, 1));
+
+  ball.is_detected = pos_var < kMaxPositionVariance;
+  if (ball.is_detected) {
     ball.area = max_area;
-    ball.pos_image.x = r.x + r.width / 2;
-    ball.pos_image.y = r.y + r.height / 2;
-    ball.radius = (r.width + r.height + 4) / 4;
+    ball.pos_image.x = state.at<float>(0);
+    ball.pos_image.y = state.at<float>(1);
+    ball.radius = (state.at<float>(4) + state.at<float>(5) + 4) / 4;
     ball.certainty = max_circularity;
   }
 }

--- a/edante/vision/src/vision_node.cpp
+++ b/edante/vision/src/vision_node.cpp
@@ -69,7 +69,8 @@ void VisionNode::Spin() {
 
       // Get a shared cv::Mat from the image message
       Mat mat = Mat(image.height, image.width, CV_8UC1, image.data.data());
-      ball_detector_.ProcessImage(mat, image.header, cam_model, transform);
+      ball_detector_.ProcessImage(mat, horizon_level, image.header, cam_model,
+                                  transform);
       head_tracker_.Track(ball_detector_.ball(), head_angles[1]);
 
       // Disable line tracking for now


### PR DESCRIPTION
Implement a Kalman filter which is used to track the ball in the
image. The state consists of [x, y, vx, vy, w, h], where (x, y) is
the ball position; (vx, vy) is the ball velocity; (w, h) is the
size of the bounding box of the detected blob.
